### PR TITLE
docs: prefix API endpoints with version

### DIFF
--- a/Auth/EN/Endpoints/AuthKeepAlive.md
+++ b/Auth/EN/Endpoints/AuthKeepAlive.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`GET /auth/keep-alive`
+`GET /api/v1/auth/keep-alive`
 
 Checks whether the provided token is valid and keeps the user session active.
 

--- a/Auth/EN/Endpoints/AuthLogout.md
+++ b/Auth/EN/Endpoints/AuthLogout.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`POST /auth/logout`
+`POST /api/v1/auth/logout`
 
 Ends the user session by invalidating the access token.
 

--- a/Auth/EN/Endpoints/Authentication.md
+++ b/Auth/EN/Endpoints/Authentication.md
@@ -4,7 +4,7 @@
 
 ## Endpoint
 
-`POST /auth`
+`POST /api/v1/auth`
 
 Authenticates a user.
 
@@ -37,7 +37,7 @@ Basic Auth. Send the header `Authorization: Basic <credentials>`, where `<creden
 ## Request Example
 
 ```http
-POST /auth HTTP/1.1
+POST /api/v1/auth HTTP/1.1
 Authorization: Basic am9hbzpzZW5oYQ==
 X-PUBLIC-KEY: 00000000-0000-0000-0000-000000000000
 Accept-Language: en

--- a/Auth/EN/Endpoints/UserRegister.md
+++ b/Auth/EN/Endpoints/UserRegister.md
@@ -4,7 +4,7 @@
 
 ## Endpoint
 
-`POST auth/register`
+`POST /api/v1/auth/register`
 
 Registers a new user on the platform.
 

--- a/Auth/ES/Endpoints/AuthKeepAlive.md
+++ b/Auth/ES/Endpoints/AuthKeepAlive.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`GET /auth/keep-alive`
+`GET /api/v1/auth/keep-alive`
 
 Verifica si el token proporcionado es válido y mantiene activa la sesión del usuario.
 

--- a/Auth/ES/Endpoints/AuthLogout.md
+++ b/Auth/ES/Endpoints/AuthLogout.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`POST /auth/logout`
+`POST /api/v1/auth/logout`
 
 Finaliza la sesión del usuario invalidando el token de acceso.
 

--- a/Auth/ES/Endpoints/Authentication.md
+++ b/Auth/ES/Endpoints/Authentication.md
@@ -4,7 +4,7 @@
 
 ## Endpoint
 
-`POST /auth`
+`POST /api/v1/auth`
 
 Realiza la autenticación de un usuario.
 
@@ -37,7 +37,7 @@ Basic Auth. Envíe el encabezado `Authorization: Basic <credenciales>`, donde `<
 ## Ejemplo de Solicitud
 
 ```http
-POST /auth HTTP/1.1
+POST /api/v1/auth HTTP/1.1
 Authorization: Basic am9hbzpzZW5oYQ==
 X-PUBLIC-KEY: 00000000-0000-0000-0000-000000000000
 Accept-Language: es

--- a/Auth/ES/Endpoints/UserRegister.md
+++ b/Auth/ES/Endpoints/UserRegister.md
@@ -4,7 +4,7 @@
 
 ## Endpoint
 
-`POST auth/register`
+`POST /api/v1/auth/register`
 
 Registra un nuevo usuario en la plataforma.
 

--- a/Auth/PT/Endpoints/AuthKeepAlive.md
+++ b/Auth/PT/Endpoints/AuthKeepAlive.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`GET /auth/keep-alive`
+`GET /api/v1/auth/keep-alive`
 
 Verifica se o token fornecido é válido e mantém a sessão do usuário ativa.
 

--- a/Auth/PT/Endpoints/AuthLogout.md
+++ b/Auth/PT/Endpoints/AuthLogout.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`POST /auth/logout`
+`POST /api/v1/auth/logout`
 
 Encerra a sessão do usuário invalidando o token de acesso.
 

--- a/Auth/PT/Endpoints/Authentication.md
+++ b/Auth/PT/Endpoints/Authentication.md
@@ -4,7 +4,7 @@
 
 ## Endpoint
 
-`POST /auth`
+`POST /api/v1/auth`
 
 Realiza a autenticação de um usuário.
 
@@ -37,7 +37,7 @@ Basic Auth. Envie o cabeçalho `Authorization: Basic <credenciais>`, onde `<cred
 ## Exemplo de Requisição
 
 ```http
-POST /auth HTTP/1.1
+POST /api/v1/auth HTTP/1.1
 Authorization: Basic am9hbzpzZW5oYQ==
 X-PUBLIC-KEY: 00000000-0000-0000-0000-000000000000
 Accept-Language: pt-BR

--- a/Auth/PT/Endpoints/UserRegister.md
+++ b/Auth/PT/Endpoints/UserRegister.md
@@ -4,7 +4,7 @@
 
 ## Endpoint
 
-`POST auth/register`
+`POST /api/v1/auth/register`
 
 Registra um novo usuário na plataforma.
 

--- a/Footprints/EN/Endpoints/FootprintsShow.md
+++ b/Footprints/EN/Endpoints/FootprintsShow.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`GET /footprints/{footprint}`
+`GET /api/v1/footprints/{footprint}`
 
 Retrieves detailed information about a specific footprint.
 

--- a/Footprints/EN/Endpoints/FootprintsStore.md
+++ b/Footprints/EN/Endpoints/FootprintsStore.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`POST /footprints`
+`POST /api/v1/footprints`
 
 Registers a navigation trace or visitor interaction.
 

--- a/Footprints/ES/Endpoints/FootprintsShow.md
+++ b/Footprints/ES/Endpoints/FootprintsShow.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`GET /footprints/{footprint}`
+`GET /api/v1/footprints/{footprint}`
 
 Obtiene información detallada sobre un footprint específico.
 

--- a/Footprints/ES/Endpoints/FootprintsStore.md
+++ b/Footprints/ES/Endpoints/FootprintsStore.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`POST /footprints`
+`POST /api/v1/footprints`
 
 Registra un rastro de navegación o interacción del visitante.
 

--- a/Footprints/PT/Endpoints/FootprintsShow.md
+++ b/Footprints/PT/Endpoints/FootprintsShow.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`GET /footprints/{footprint}`
+`GET /api/v1/footprints/{footprint}`
 
 Recupera informações detalhadas sobre um footprint específico.
 

--- a/Footprints/PT/Endpoints/FootprintsStore.md
+++ b/Footprints/PT/Endpoints/FootprintsStore.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`POST /footprints`
+`POST /api/v1/footprints`
 
 Registra um rastro de navegação ou interação do visitante.
 


### PR DESCRIPTION
## Summary
- prefix all documented endpoints with `/api/v1`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e3cb95d48332a7fb2676d6436025