### PR TITLE
Development

### DIFF
--- a/Auth/EN/Endpoints/AuthKeepAlive.md
+++ b/Auth/EN/Endpoints/AuthKeepAlive.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`GET /auth/keep-alive`
+`GET /api/v1/auth/keep-alive`
 
 Checks whether the provided token is valid and keeps the user session active.
 

--- a/Auth/EN/Endpoints/AuthLogout.md
+++ b/Auth/EN/Endpoints/AuthLogout.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`POST /auth/logout`
+`POST /api/v1/auth/logout`
 
 Ends the user session by invalidating the access token.
 

--- a/Auth/EN/Endpoints/Authentication.md
+++ b/Auth/EN/Endpoints/Authentication.md
@@ -1,4 +1,6 @@
-# Auth – Authenticate User
+<!-- markdownlint-disable MD013 -->
+
+# Authentication – Authenticate User
 
 ## Endpoint
 
@@ -34,7 +36,7 @@ Basic Auth. Send the header `Authorization: Basic <credentials>`, where `<creden
 
 ## Request Example
 
-```
+```http
 POST /auth HTTP/1.1
 Authorization: Basic am9hbzpzZW5oYQ==
 X-PUBLIC-KEY: 00000000-0000-0000-0000-000000000000
@@ -57,7 +59,7 @@ Content-Type: application/json
   "data": {
     "user": {
       "uuid": "00000000-0000-0000-0000-000000000000",
-      "echo_uuid": "e1c1h1o11111111111111111111111111111",
+      "echo_uuid": "e1c1h1o1111111111111111111111111111",
       "name": "Sample User",
       "email": "sample.user@domain.com",
       "avatar": {
@@ -116,3 +118,5 @@ Content-Type: application/json
 
 * The token must be sent in future authenticated requests.
 * The `device` field helps identify the accessing device.
+
+<!-- markdownlint-enable MD013 -->

--- a/Auth/EN/Endpoints/Authentication.md
+++ b/Auth/EN/Endpoints/Authentication.md
@@ -4,7 +4,7 @@
 
 ## Endpoint
 
-`POST /auth`
+`POST /api/v1/auth`
 
 Authenticates a user.
 
@@ -37,7 +37,7 @@ Basic Auth. Send the header `Authorization: Basic <credentials>`, where `<creden
 ## Request Example
 
 ```http
-POST /auth HTTP/1.1
+POST /api/v1/auth HTTP/1.1
 Authorization: Basic am9hbzpzZW5oYQ==
 X-PUBLIC-KEY: 00000000-0000-0000-0000-000000000000
 Accept-Language: en

--- a/Auth/EN/Endpoints/UserRegister.md
+++ b/Auth/EN/Endpoints/UserRegister.md
@@ -4,7 +4,7 @@
 
 ## Endpoint
 
-`POST auth/register`
+`POST /api/v1/auth/register`
 
 Registers a new user on the platform.
 

--- a/Auth/EN/Endpoints/UserRegister.md
+++ b/Auth/EN/Endpoints/UserRegister.md
@@ -1,4 +1,6 @@
-# Auth – Register User
+<!-- markdownlint-disable MD013 -->
+
+# User – Register User
 
 ## Endpoint
 
@@ -111,7 +113,7 @@ None. Still, the `X-PUBLIC-KEY` header must be sent.
   "data": {
     "user": {
       "uuid": "00000000-0000-0000-0000-000000000000",
-      "echo_uuid": "e000000000000000000000000000000000000",
+      "echo_uuid": "e1c1h1o1111111111111111111111111111",
       "name": "User Example",
       "email": "user@example.com",
       "avatar": {
@@ -147,3 +149,5 @@ None. Still, the `X-PUBLIC-KEY` header must be sent.
 Returns an object with validation error messages.
 
 ---
+
+<!-- markdownlint-enable MD013 -->

--- a/Auth/ES/Endpoints/AuthKeepAlive.md
+++ b/Auth/ES/Endpoints/AuthKeepAlive.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`GET /auth/keep-alive`
+`GET /api/v1/auth/keep-alive`
 
 Verifica si el token proporcionado es válido y mantiene activa la sesión del usuario.
 

--- a/Auth/ES/Endpoints/AuthLogout.md
+++ b/Auth/ES/Endpoints/AuthLogout.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`POST /auth/logout`
+`POST /api/v1/auth/logout`
 
 Finaliza la sesión del usuario invalidando el token de acceso.
 

--- a/Auth/ES/Endpoints/Authentication.md
+++ b/Auth/ES/Endpoints/Authentication.md
@@ -1,4 +1,6 @@
-# Auth – Autenticar Usuario
+<!-- markdownlint-disable MD013 -->
+
+# Authentication – Autenticar Usuario
 
 ## Endpoint
 
@@ -34,7 +36,7 @@ Basic Auth. Envíe el encabezado `Authorization: Basic <credenciales>`, donde `<
 
 ## Ejemplo de Solicitud
 
-```
+```http
 POST /auth HTTP/1.1
 Authorization: Basic am9hbzpzZW5oYQ==
 X-PUBLIC-KEY: 00000000-0000-0000-0000-000000000000
@@ -57,7 +59,7 @@ Content-Type: application/json
   "data": {
     "user": {
       "uuid": "00000000-0000-0000-0000-000000000000",
-      "echo_uuid": "11111111-1111-1111-1111-111111111111",
+      "echo_uuid": "e1c1h1o1111111111111111111111111111",
       "name": "Usuario Ejemplo",
       "email": "usuario.ejemplo@dominio.com",
       "avatar": {
@@ -116,3 +118,5 @@ Content-Type: application/json
 
 * El token debe enviarse en futuras solicitudes autenticadas.
 * El campo `device` ayuda a identificar el dispositivo de acceso.
+
+<!-- markdownlint-enable MD013 -->

--- a/Auth/ES/Endpoints/Authentication.md
+++ b/Auth/ES/Endpoints/Authentication.md
@@ -4,7 +4,7 @@
 
 ## Endpoint
 
-`POST /auth`
+`POST /api/v1/auth`
 
 Realiza la autenticación de un usuario.
 
@@ -37,7 +37,7 @@ Basic Auth. Envíe el encabezado `Authorization: Basic <credenciales>`, donde `<
 ## Ejemplo de Solicitud
 
 ```http
-POST /auth HTTP/1.1
+POST /api/v1/auth HTTP/1.1
 Authorization: Basic am9hbzpzZW5oYQ==
 X-PUBLIC-KEY: 00000000-0000-0000-0000-000000000000
 Accept-Language: es

--- a/Auth/ES/Endpoints/UserRegister.md
+++ b/Auth/ES/Endpoints/UserRegister.md
@@ -4,7 +4,7 @@
 
 ## Endpoint
 
-`POST auth/register`
+`POST /api/v1/auth/register`
 
 Registra un nuevo usuario en la plataforma.
 

--- a/Auth/ES/Endpoints/UserRegister.md
+++ b/Auth/ES/Endpoints/UserRegister.md
@@ -1,4 +1,6 @@
-# Auth – Registrar Usuario
+<!-- markdownlint-disable MD013 -->
+
+# User – Registrar Usuario
 
 ## Endpoint
 
@@ -111,7 +113,7 @@ Ninguna. Aun así, se debe enviar el encabezado `X-PUBLIC-KEY`.
   "data": {
     "user": {
       "uuid": "00000000-0000-0000-0000-000000000000",
-      "echo_uuid": "e000000000000000000000000000000000000",
+      "echo_uuid": "e1c1h1o1111111111111111111111111111",
       "name": "Usuario Ejemplo",
       "email": "usuario@example.com",
       "avatar": {
@@ -147,3 +149,5 @@ Ninguna. Aun así, se debe enviar el encabezado `X-PUBLIC-KEY`.
 Retorna un objeto con mensajes de error de validación.
 
 ---
+
+<!-- markdownlint-enable MD013 -->

--- a/Auth/PT/Endpoints/AuthKeepAlive.md
+++ b/Auth/PT/Endpoints/AuthKeepAlive.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`GET /auth/keep-alive`
+`GET /api/v1/auth/keep-alive`
 
 Verifica se o token fornecido é válido e mantém a sessão do usuário ativa.
 

--- a/Auth/PT/Endpoints/AuthLogout.md
+++ b/Auth/PT/Endpoints/AuthLogout.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`POST /auth/logout`
+`POST /api/v1/auth/logout`
 
 Encerra a sessão do usuário invalidando o token de acesso.
 

--- a/Auth/PT/Endpoints/Authentication.md
+++ b/Auth/PT/Endpoints/Authentication.md
@@ -4,7 +4,7 @@
 
 ## Endpoint
 
-`POST /auth`
+`POST /api/v1/auth`
 
 Realiza a autenticação de um usuário.
 
@@ -37,7 +37,7 @@ Basic Auth. Envie o cabeçalho `Authorization: Basic <credenciais>`, onde `<cred
 ## Exemplo de Requisição
 
 ```http
-POST /auth HTTP/1.1
+POST /api/v1/auth HTTP/1.1
 Authorization: Basic am9hbzpzZW5oYQ==
 X-PUBLIC-KEY: 00000000-0000-0000-0000-000000000000
 Accept-Language: pt-BR

--- a/Auth/PT/Endpoints/Authentication.md
+++ b/Auth/PT/Endpoints/Authentication.md
@@ -1,4 +1,6 @@
-# Auth – Autenticar Usuário
+<!-- markdownlint-disable MD013 -->
+
+# Authentication – Autenticar Usuário
 
 ## Endpoint
 
@@ -34,7 +36,7 @@ Basic Auth. Envie o cabeçalho `Authorization: Basic <credenciais>`, onde `<cred
 
 ## Exemplo de Requisição
 
-```
+```http
 POST /auth HTTP/1.1
 Authorization: Basic am9hbzpzZW5oYQ==
 X-PUBLIC-KEY: 00000000-0000-0000-0000-000000000000
@@ -57,7 +59,7 @@ Content-Type: application/json
   "data": {
     "user": {
       "uuid": "00000000-0000-0000-0000-000000000000",
-      "echo_uuid": "11111111-1111-1111-1111-111111111111",
+      "echo_uuid": "e1c1h1o1111111111111111111111111111",
       "name": "Usuário Exemplo",
       "email": "usuario.exemplo@dominio.com",
       "avatar": {
@@ -116,3 +118,5 @@ Content-Type: application/json
 
 * O token deve ser enviado em futuras requisições autenticadas.
 * O campo `device` auxilia na identificação do equipamento de acesso.
+
+<!-- markdownlint-enable MD013 -->

--- a/Auth/PT/Endpoints/UserRegister.md
+++ b/Auth/PT/Endpoints/UserRegister.md
@@ -4,7 +4,7 @@
 
 ## Endpoint
 
-`POST auth/register`
+`POST /api/v1/auth/register`
 
 Registra um novo usuário na plataforma.
 

--- a/Auth/PT/Endpoints/UserRegister.md
+++ b/Auth/PT/Endpoints/UserRegister.md
@@ -1,4 +1,6 @@
-# Auth – Registrar Usuário
+<!-- markdownlint-disable MD013 -->
+
+# User – Registrar Usuário
 
 ## Endpoint
 
@@ -111,7 +113,7 @@ Nenhuma. Ainda assim, o cabeçalho `X-PUBLIC-KEY` deve ser enviado.
   "data": {
     "user": {
       "uuid": "00000000-0000-0000-0000-000000000000",
-      "echo_uuid": "e000000000000000000000000000000000000",
+      "echo_uuid": "e1c1h1o1111111111111111111111111111",
       "name": "Usuário Exemplo",
       "email": "usuario@example.com",
       "avatar": {
@@ -147,3 +149,5 @@ Nenhuma. Ainda assim, o cabeçalho `X-PUBLIC-KEY` deve ser enviado.
 Retorna um objeto com mensagens de erro de validação.
 
 ---
+
+<!-- markdownlint-enable MD013 -->

--- a/Footprints/EN/Endpoints/FootprintsShow.md
+++ b/Footprints/EN/Endpoints/FootprintsShow.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`GET /footprints/{footprint}`
+`GET /api/v1/footprints/{footprint}`
 
 Retrieves detailed information about a specific footprint.
 

--- a/Footprints/EN/Endpoints/FootprintsStore.md
+++ b/Footprints/EN/Endpoints/FootprintsStore.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`POST /footprints`
+`POST /api/v1/footprints`
 
 Registers a navigation trace or visitor interaction.
 

--- a/Footprints/ES/Endpoints/FootprintsShow.md
+++ b/Footprints/ES/Endpoints/FootprintsShow.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`GET /footprints/{footprint}`
+`GET /api/v1/footprints/{footprint}`
 
 Obtiene información detallada sobre un footprint específico.
 

--- a/Footprints/ES/Endpoints/FootprintsStore.md
+++ b/Footprints/ES/Endpoints/FootprintsStore.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`POST /footprints`
+`POST /api/v1/footprints`
 
 Registra un rastro de navegación o interacción del visitante.
 

--- a/Footprints/PT/Endpoints/FootprintsShow.md
+++ b/Footprints/PT/Endpoints/FootprintsShow.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`GET /footprints/{footprint}`
+`GET /api/v1/footprints/{footprint}`
 
 Recupera informações detalhadas sobre um footprint específico.
 

--- a/Footprints/PT/Endpoints/FootprintsStore.md
+++ b/Footprints/PT/Endpoints/FootprintsStore.md
@@ -2,7 +2,7 @@
 
 ## Endpoint
 
-`POST /footprints`
+`POST /api/v1/footprints`
 
 Registra um rastro de navegação ou interação do visitante.
 


### PR DESCRIPTION
This pull request updates the documentation for authentication and footprint endpoints in English, Spanish, and Portuguese to reflect a new API path structure. All endpoint URLs are now prefixed with `/api/v1/`, ensuring consistency and clarity across the API documentation.

**Auth Endpoints Documentation Updates:**

* All authentication-related endpoints in English, Spanish, and Portuguese (`AuthKeepAlive`, `AuthLogout`, `Authentication`, and `UserRegister`) now use the `/api/v1/auth/...` prefix instead of `/auth/...`. [[1]](diffhunk://#diff-3f68ea76f02e6ea95a3cb77fc48074a80016084d1e272d204b7f61b67c564f12L5-R5) [[2]](diffhunk://#diff-b83322bf9079416a2dc7b880d25ba927adf68bbb9c0f90c8d4b25e2eba57c19eL5-R5) [[3]](diffhunk://#diff-33c2010c0b8b4abfa8f21a2d46618b99ee05d2579683c6abea5109a78830c44dL7-R7) [[4]](diffhunk://#diff-33c2010c0b8b4abfa8f21a2d46618b99ee05d2579683c6abea5109a78830c44dL40-R40) [[5]](diffhunk://#diff-d52a3e0d7625bb5cb0e98adfc074d32b041a9f8b7d72e6993556959df7d1bc12L7-R7) [[6]](diffhunk://#diff-a8e77b8bde46e872a78ce74009f191c71bc2bacaca1b53ae919c3692cc1ce9f1L5-R5) [[7]](diffhunk://#diff-4a0ed5bf423e10e886916c71be4b070970d3cf9b5f6a51c3293db80d690614b9L5-R5) [[8]](diffhunk://#diff-10789d793b19a847e567af6dbf6055dad25f0d113dc78df6954808ed328cdedbL7-R7) [[9]](diffhunk://#diff-10789d793b19a847e567af6dbf6055dad25f0d113dc78df6954808ed328cdedbL40-R40) [[10]](diffhunk://#diff-ea2a4d396ea1bee2969d87b9107ea884042c3476656e1f31bc4b3ddc813fdea3L7-R7) [[11]](diffhunk://#diff-6704db7b29cccbce9c9dee80addf66e6e8dec8d9dc4def93f935cfd319b47e1aL5-R5) [[12]](diffhunk://#diff-9972bfe16721ccd8e5232def8904e55508014ae24f433910918f9a2b7f1dfb4cL5-R5) [[13]](diffhunk://#diff-e9f99a8c1763f2beee7ec1967d6ee017cea8ac42d3fff8773573242b634af79eL7-R7) [[14]](diffhunk://#diff-e9f99a8c1763f2beee7ec1967d6ee017cea8ac42d3fff8773573242b634af79eL40-R40) [[15]](diffhunk://#diff-058f614cbc991dd86cc046f3f7f22f12941df94f72b53a16fe868093e3f7c50cL7-R7)

**Footprints Endpoints Documentation Updates:**

* All footprints-related endpoints in English, Spanish, and Portuguese (`FootprintsShow` and `FootprintsStore`) now use the `/api/v1/footprints...` prefix instead of `/footprints...`. [[1]](diffhunk://#diff-c148a0879c8e21c186655d4e719607e4abddf0662f8febaa0294b88e108deb69L5-R5) [[2]](diffhunk://#diff-3195397eaffc9a9c3f8d0ecdb177b00bf06b6978ca9156c588b717c007a69eeeL5-R5) [[3]](diffhunk://#diff-d719b379c2da87e927e56cb0fbf69e69a17a368e816479177f9a86c0534b3bedL5-R5) [[4]](diffhunk://#diff-0927984959ba81240611f9796f7fa716acb2691412203a55c06428b9ab89bf51L5-R5) [[5]](diffhunk://#diff-dc0e658ba9f52cfb3f90d16000d1fce1b6cd944d94795f18d8c7b57c0091b181L5-R5) [[6]](diffhunk://#diff-8078d37ffb2b63657532d1a517d8efa9f692cc7c66d0daa461b9c9c9405d2befL5-R5)

**Request Example Updates:**

* Example HTTP requests in the authentication documentation have been updated to use the new `/api/v1/auth` endpoint in all supported languages. [[1]](diffhunk://#diff-33c2010c0b8b4abfa8f21a2d46618b99ee05d2579683c6abea5109a78830c44dL40-R40) [[2]](diffhunk://#diff-10789d793b19a847e567af6dbf6055dad25f0d113dc78df6954808ed328cdedbL40-R40) [[3]](diffhunk://#diff-e9f99a8c1763f2beee7ec1967d6ee017cea8ac42d3fff8773573242b634af79eL40-R40)