### PR TITLE
docs: add IA admin profile endpoint

### DIFF
--- a/IA/EN/Endpoints/IaAdminMe.md
+++ b/IA/EN/Endpoints/IaAdminMe.md
@@ -1,0 +1,100 @@
+<!-- markdownlint-disable MD013 -->
+
+# IA – Admin Profile Endpoint
+
+## Endpoint
+
+`GET /api/v1/ia/admin/me`
+
+Returns the authenticated user's profile for the current platform.
+
+---
+
+## Authentication
+
+Bearer token via Sanctum.
+
+---
+
+## Request
+
+### Required Headers
+
+| Header | Type | Description |
+| ------ | ---- | ----------- |
+| **Authorization** | `string` | Bearer {token} credential. |
+| **X-PUBLIC-KEY** | `string` | Public key identifying the platform. |
+| **Accept-Language** | `string` | Locale for translatable fields. Optional. |
+
+No query parameters are supported.
+
+---
+
+## Example Response
+
+```json
+{
+  "id": 123,
+  "uuid": "u1v2w3x4-y5z6-7890-1234-56789abcdef0",
+  "name": "Jane Doe",
+  "gender": "female",
+  "birth_date": "1990-05-12",
+  "email": "jane@example.com",
+  "roles": ["admin"],
+  "permissions": ["store.company"],
+  "contacts": {
+    "public_email": {
+      "email": "jane.public@example.com",
+      "type": "public_email"
+    },
+    "whatsapp": {
+      "ddi": "+55",
+      "ddd": "11",
+      "number": "999999999",
+      "full": "+55 11 99999-9999",
+      "type": "whatsapp"
+    }
+  },
+  "platform": {"id": 1, "name": "PlatformName"},
+  "images": {
+    "avatar": {
+      "uuid": "img-uuid",
+      "unique_id": "a1b2c3",
+      "usage": "avatar",
+      "url": "https://cdn.example.com/avatar.jpg",
+      "name": "Avatar",
+      "slug": "avatar",
+      "width": 512,
+      "height": 512,
+      "creation_date": "2025-01-01T12:00:00Z"
+    }
+  }
+}
+```
+
+---
+
+## JSON Structure Explanation
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `id` | `integer` | User ID. |
+| `uuid` | `uuid` | User identifier. |
+| `name` | `string` | Full name. |
+| `gender` | `string` | Gender. |
+| `birth_date` | `date` | Birth date. |
+| `email` | `string` | Contact email. |
+| `roles[]` | `array` | Assigned roles within the platform. |
+| `permissions[]` | `array` | Granted permissions. |
+| `contacts` | `object` | Public contact information keyed by type. |
+| `platform` | `object` | Platform summary (id, name). |
+| `images` | `object` | Uploaded images keyed by usage. |
+
+---
+
+## Notes
+
+* `401 Unauthorized` for missing or invalid token.
+* `403 Forbidden` when the user lacks a non-guest role on the platform.
+
+<!-- markdownlint-enable MD013 -->

--- a/IA/EN/Endpoints/Index.md
+++ b/IA/EN/Endpoints/Index.md
@@ -1,0 +1,4 @@
+# Endpoints
+
+List of API endpoints.
+

--- a/IA/EN/README.md
+++ b/IA/EN/README.md
@@ -1,0 +1,6 @@
+# IA
+
+Endpoints for IA operations.
+
+Each platform must include the `X-PUBLIC-KEY` header to authenticate and receive responses. The frontend should send the current application language via the `Accept-Language` header (e.g., `en`, `pt-BR`).
+

--- a/IA/ES/Endpoints/IaAdminMe.md
+++ b/IA/ES/Endpoints/IaAdminMe.md
@@ -1,0 +1,100 @@
+<!-- markdownlint-disable MD013 -->
+
+# IA – Perfil de Administrador
+
+## Endpoint
+
+`GET /api/v1/ia/admin/me`
+
+Devuelve el perfil del usuario autenticado para la plataforma actual.
+
+---
+
+## Autenticación
+
+Token Bearer vía Sanctum.
+
+---
+
+## Solicitud
+
+### Encabezados Obligatorios
+
+| Encabezado | Tipo | Descripción |
+| ---------- | ---- | ----------- |
+| **Authorization** | `string` | Credencial Bearer {token}. |
+| **X-PUBLIC-KEY** | `string` | Clave pública que identifica la plataforma. |
+| **Accept-Language** | `string` | Idioma para campos traducibles. Opcional. |
+
+No se admiten parámetros de consulta.
+
+---
+
+## Ejemplo de Respuesta
+
+```json
+{
+  "id": 123,
+  "uuid": "u1v2w3x4-y5z6-7890-1234-56789abcdef0",
+  "name": "Jane Doe",
+  "gender": "female",
+  "birth_date": "1990-05-12",
+  "email": "jane@example.com",
+  "roles": ["admin"],
+  "permissions": ["store.company"],
+  "contacts": {
+    "public_email": {
+      "email": "jane.public@example.com",
+      "type": "public_email"
+    },
+    "whatsapp": {
+      "ddi": "+55",
+      "ddd": "11",
+      "number": "999999999",
+      "full": "+55 11 99999-9999",
+      "type": "whatsapp"
+    }
+  },
+  "platform": {"id": 1, "name": "PlatformName"},
+  "images": {
+    "avatar": {
+      "uuid": "img-uuid",
+      "unique_id": "a1b2c3",
+      "usage": "avatar",
+      "url": "https://cdn.example.com/avatar.jpg",
+      "name": "Avatar",
+      "slug": "avatar",
+      "width": 512,
+      "height": 512,
+      "creation_date": "2025-01-01T12:00:00Z"
+    }
+  }
+}
+```
+
+---
+
+## Estructura JSON
+
+| Campo | Tipo | Descripción |
+| ----- | ---- | ----------- |
+| `id` | `integer` | ID del usuario. |
+| `uuid` | `uuid` | Identificador del usuario. |
+| `name` | `string` | Nombre completo. |
+| `gender` | `string` | Género. |
+| `birth_date` | `date` | Fecha de nacimiento. |
+| `email` | `string` | Correo electrónico de contacto. |
+| `roles[]` | `array` | Roles asignados dentro de la plataforma. |
+| `permissions[]` | `array` | Permisos concedidos. |
+| `contacts` | `object` | Información de contacto pública organizada por tipo. |
+| `platform` | `object` | Resumen de la plataforma (id, nombre). |
+| `images` | `object` | Imágenes cargadas organizadas por uso. |
+
+---
+
+## Notas
+
+* `401 Unauthorized` cuando falta o es inválido el token.
+* `403 Forbidden` cuando el usuario no posee un rol distinto de invitado en la plataforma.
+
+<!-- markdownlint-enable MD013 -->

--- a/IA/ES/Endpoints/Index.md
+++ b/IA/ES/Endpoints/Index.md
@@ -1,0 +1,4 @@
+# Endpoints
+
+Lista de endpoints de la API.
+

--- a/IA/ES/README.md
+++ b/IA/ES/README.md
@@ -1,0 +1,6 @@
+# IA
+
+Endpoints para operaciones de IA.
+
+Cada plataforma debe incluir el encabezado `X-PUBLIC-KEY` para autenticar y recibir respuestas. El frontend debe enviar el idioma actual de la aplicación mediante el encabezado `Accept-Language` (ej.: `en`, `pt-BR`).
+

--- a/IA/PT/Endpoints/IaAdminMe.md
+++ b/IA/PT/Endpoints/IaAdminMe.md
@@ -1,0 +1,100 @@
+<!-- markdownlint-disable MD013 -->
+
+# IA – Perfil do Administrador
+
+## Endpoint
+
+`GET /api/v1/ia/admin/me`
+
+Retorna o perfil do usuário autenticado para a plataforma atual.
+
+---
+
+## Autenticação
+
+Token Bearer via Sanctum.
+
+---
+
+## Requisição
+
+### Cabeçalhos Obrigatórios
+
+| Cabeçalho | Tipo | Descrição |
+| --------- | ---- | --------- |
+| **Authorization** | `string` | Credencial Bearer {token}. |
+| **X-PUBLIC-KEY** | `string` | Chave pública que identifica a plataforma. |
+| **Accept-Language** | `string` | Idioma para campos traduzíveis. Opcional. |
+
+Nenhum parâmetro de consulta é suportado.
+
+---
+
+## Exemplo de Resposta
+
+```json
+{
+  "id": 123,
+  "uuid": "u1v2w3x4-y5z6-7890-1234-56789abcdef0",
+  "name": "Jane Doe",
+  "gender": "female",
+  "birth_date": "1990-05-12",
+  "email": "jane@example.com",
+  "roles": ["admin"],
+  "permissions": ["store.company"],
+  "contacts": {
+    "public_email": {
+      "email": "jane.public@example.com",
+      "type": "public_email"
+    },
+    "whatsapp": {
+      "ddi": "+55",
+      "ddd": "11",
+      "number": "999999999",
+      "full": "+55 11 99999-9999",
+      "type": "whatsapp"
+    }
+  },
+  "platform": {"id": 1, "name": "PlatformName"},
+  "images": {
+    "avatar": {
+      "uuid": "img-uuid",
+      "unique_id": "a1b2c3",
+      "usage": "avatar",
+      "url": "https://cdn.example.com/avatar.jpg",
+      "name": "Avatar",
+      "slug": "avatar",
+      "width": 512,
+      "height": 512,
+      "creation_date": "2025-01-01T12:00:00Z"
+    }
+  }
+}
+```
+
+---
+
+## Estrutura JSON
+
+| Campo | Tipo | Descrição |
+| ----- | ---- | --------- |
+| `id` | `integer` | ID do usuário. |
+| `uuid` | `uuid` | Identificador do usuário. |
+| `name` | `string` | Nome completo. |
+| `gender` | `string` | Gênero. |
+| `birth_date` | `date` | Data de nascimento. |
+| `email` | `string` | Email de contato. |
+| `roles[]` | `array` | Perfis atribuídos na plataforma. |
+| `permissions[]` | `array` | Permissões concedidas. |
+| `contacts` | `object` | Contatos públicos organizados por tipo. |
+| `platform` | `object` | Resumo da plataforma (id, nome). |
+| `images` | `object` | Imagens enviadas organizadas por uso. |
+
+---
+
+## Notas
+
+* `401 Unauthorized` para token ausente ou inválido.
+* `403 Forbidden` se o usuário não possuir papel diferente de convidado na plataforma.
+
+<!-- markdownlint-enable MD013 -->

--- a/IA/PT/Endpoints/Index.md
+++ b/IA/PT/Endpoints/Index.md
@@ -1,0 +1,4 @@
+# Endpoints
+
+Lista de endpoints da API.
+

--- a/IA/PT/README.md
+++ b/IA/PT/README.md
@@ -1,0 +1,6 @@
+# IA
+
+Endpoints para operações de IA.
+
+Cada plataforma deve incluir o cabeçalho `X-PUBLIC-KEY` para autenticar e receber respostas. O frontend deve enviar o idioma atual da aplicação por meio do cabeçalho `Accept-Language` (ex.: `en`, `pt-BR`).
+

--- a/IA/README.md
+++ b/IA/README.md
@@ -1,0 +1,6 @@
+# IA
+
+Endpoints for IA operations.
+
+Each platform must include the `X-PUBLIC-KEY` header to authenticate and receive responses. The frontend should send the current application language via the `Accept-Language` header (e.g., `en`, `pt-BR`).
+


### PR DESCRIPTION
## Summary
- document IA admin profile endpoint
- add English, Spanish, and Portuguese translations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b08ef581408332b27e58656e3265ac